### PR TITLE
Add fallback color CSS utilities

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,5 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Safelist red + blue colors manually for test */
-@source inline("text-red-500 text-blue-500");
+/* PurgeCSS will automatically detect Tailwind classes used in React */
+
+/* Temporary color utilities due to Tailwind plugin issues */
+.text-blue-700 { color: #1d4ed8; }
+.text-blue-500 { color: #3b82f6; }
+.text-blue-400 { color: #60a5fa; }
+.text-red-500 { color: #ef4444; }
+.text-gray-900 { color: #111827; }
+.text-gray-800 { color: #1f2937; }
+.text-gray-700 { color: #374151; }
+.text-gray-600 { color: #4b5563; }
+.text-gray-500 { color: #6b7280; }
+.text-gray-400 { color: #9ca3af; }


### PR DESCRIPTION
## Summary
- manually define color utility classes in `src/index.css` to address Tailwind color issues

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a17f0b5e883278e2574b7b34fbf97